### PR TITLE
fix: refactor variables and fix critical bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Ansible automation for building and installing Linux kernels from source, with specialized support for reproducing syzkaller-reported kernel bugs. Targets Fedora/RHEL-based systems.
+
+## Common Commands
+
+### Build Kernels
+
+```bash
+# Build stable kernel from kernel.org (uses vars/kernel_vars.yml)
+ansible-playbook -i inventory.ini build_kernel.yml
+
+# Build latest kernel from git (uses vars/kernel_git_vars.yml)
+ansible-playbook -i inventory.ini build_kernel_from_bug.yml
+
+# Build with specific bug config (override variables)
+ansible-playbook -i inventory.ini build_kernel_from_bug.yml \
+  -e "bug_url=https://syzkaller.appspot.com/bug?extid=XXXXX" \
+  -e "install_kernel=false"
+
+# Quick build without installation using shell script
+./build_with_bug_config.sh
+```
+
+### Testing Playbooks
+
+```bash
+# Syntax check
+ansible-playbook --syntax-check build_kernel.yml
+
+# Dry run (check mode)
+ansible-playbook -i inventory.ini build_kernel.yml --check
+
+# Run with verbose output
+ansible-playbook -i inventory.ini build_kernel_from_bug.yml -v
+```
+
+## Architecture
+
+### Playbook Structure
+
+**Two main workflows:**
+
+1. **Stable kernel builds** (`build_kernel.yml`)
+   - Downloads kernel tarball from kernel.org
+   - Extracts to `/usr/src/linux-VERSION-build/`
+   - Uses `defconfig` or copies running kernel config (`oldconfig`)
+   - Always installs the kernel
+
+2. **Git-based builds** (`build_kernel_from_bug.yml`)
+   - Clones/updates linux.git to `/usr/src/linux-git/`
+   - Optionally fetches kernel config from syzkaller bug reports
+   - Supports shallow clones for faster downloads
+   - Installation is optional (controlled by `install_kernel` variable)
+
+### Task Files
+
+- `tasks/build_kernel.yml` - Stable kernel build pipeline (download → configure → build → install)
+- `tasks/fetch_kernel_git.yml` - Git repository management (clone or update)
+- `tasks/build_kernel_from_git.yml` - Git kernel build pipeline (configure → build → optional install)
+- `tasks/fetch_bug_config.yml` - Downloads kernel config from syzkaller bug URLs
+
+### Variable Files
+
+- `vars/kernel_vars.yml` - Stable kernel configuration (version, packages, paths)
+- `vars/kernel_git_vars.yml` - Git kernel configuration (repo URL, branch, bug URLs, install option)
+
+Both var files define `kernel_build_dir` - stable builds use versioned paths, git builds use `kernel_git_dir`.
+
+### Syzkaller Bug Config Workflow
+
+The `fetch_bug_config.yml` task attempts to convert a syzkaller bug URL to a kernel config URL:
+
+```
+Bug URL: https://syzkaller.appspot.com/bug?extid=XXXXX
+  ↓ (regex extraction - CURRENTLY BROKEN)
+Config URL: https://syzkaller.appspot.com/text?tag=KernelConfig&x=HASH
+```
+
+**Important:** The current regex-based URL conversion is fundamentally flawed because the config hash cannot be derived from the bug extid. Users must provide the direct `kernel_bug_config_url` or the bug page needs to be scraped.
+
+## Key Implementation Details
+
+### Build Idempotency
+
+- Stable builds: Uses `creates` parameter on unarchive and build tasks to skip if already done
+- Git builds: Uses `.build-complete` marker file to skip rebuild if present
+- Both: `make mrproper` or `make clean` run unconditionally before builds (not idempotent)
+
+### GRUB Configuration
+
+Auto-detects UEFI vs BIOS boot:
+- UEFI: `/boot/efi/EFI/redhat/grub.cfg`
+- BIOS: `/boot/grub2/grub.cfg` (default from `grub_cfg_path`)
+
+### Parallel Builds
+
+Uses `num_cores: "{{ ansible_processor_vcpus | default(2) }}"` to auto-detect CPU count for `make -j`.
+
+### Root Permissions
+
+Most tasks require `become: true` because they operate in `/usr/src/` and `/boot/`. Git builds run as root even for non-install builds.
+
+## Variable Precedence
+
+Variables can be overridden via:
+1. Playbook extra vars (`-e "var=value"`) - highest precedence
+2. `vars/` files loaded by playbook
+3. Ansible defaults - lowest precedence
+
+Common overrides: `install_kernel`, `bug_url`, `kernel_bug_config_url`, `clean_before_build`, `reboot_after_build`
+
+## Safety Mechanisms
+
+- `install_kernel: false` by default in git builds (prevents accidental system changes)
+- `reboot_after_build: false` by default (manual reboot required)
+- Build artifacts isolated in `/usr/src/` directories
+- Config validation checks (file size > 0) before build proceeds
+
+## System Requirements
+
+- Fedora/RHEL-based distribution (uses `dnf` and RedHat-specific paths)
+- 20+ GB free disk space (for full git clone)
+- Root/sudo access
+- Required packages installed via `required_packages` list in `kernel_vars.yml`

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,259 @@
+# Code Review - Issues and Improvements
+
+## Critical Issues
+
+### 1. **Broken Syzkaller Config URL Extraction**
+**File:** `tasks/fetch_bug_config.yml:4`
+
+**Problem:**
+```yaml
+config_url: "{{ bug_url | regex_replace('.*bug\\?extid=', 'https://syzkaller.appspot.com/text?tag=KernelConfig&x=') }}"
+```
+
+This regex attempts to convert a bug extid to a config hash, but this is fundamentally impossible. The config hash is not derivable from the bug extid.
+
+**Example:**
+- Bug URL: `https://syzkaller.appspot.com/bug?extid=f2b5401166003c7d09c1`
+- Attempted result: `https://syzkaller.appspot.com/text?tag=KernelConfig&x=f2b5401166003c7d09c1`
+- Actual config URL: `https://syzkaller.appspot.com/text?tag=KernelConfig&x=3e19fa1907a3dfda` (different hash)
+
+**Solution:**
+Must fetch and parse the bug page HTML to extract the actual kernel config link, or require users to always provide `kernel_bug_config_url` directly.
+
+### 2. **Missing `become: true` on make clean**
+**File:** `tasks/build_kernel.yml:45-48`
+
+**Problem:**
+```yaml
+- name: make clean
+  ansible.builtin.command: "make clean"
+  args:
+    chdir: "{{ kernel_build_dir }}"
+```
+
+The task operates in `/usr/src/` which requires root permissions, but `become: true` is missing.
+
+**Fix:** Add `become: true`
+
+## Moderate Issues
+
+### 3. **Non-Idempotent make clean**
+**File:** `tasks/build_kernel.yml:45-48`
+
+**Problem:**
+The `make clean` command runs every time the playbook executes, even if a clean was already performed. This breaks Ansible's idempotency principle.
+
+**Fix:** Either:
+- Add a condition to only clean when necessary
+- Remove it (since `make mrproper` is already used in git builds)
+- Add a variable like `clean_before_build` to control it
+
+### 4. **Variable Duplication**
+**Files:** `vars/kernel_vars.yml` and `vars/kernel_git_vars.yml`
+
+**Problem:**
+Variables like `num_cores`, `reboot_after_build` are duplicated in both files.
+
+**Impact:** DRY principle violation, maintenance burden.
+
+**Fix:** Create a `vars/common.yml` for shared variables and include it in both playbooks.
+
+### 5. **Missing grub_cfg_path in Git Vars**
+**File:** `vars/kernel_git_vars.yml`
+
+**Problem:**
+The `grub_cfg_path` variable is used in `build_kernel_from_git.yml` but only defined in `kernel_vars.yml`. If someone runs the git build playbook without loading kernel_vars.yml, it will fail.
+
+**Fix:** Either:
+- Add `grub_cfg_path` to `kernel_git_vars.yml`
+- Create a common vars file
+- Both playbooks should load common vars
+
+### 6. **Inconsistent kernel_build_dir Definition**
+**Files:** Multiple
+
+**Problem:**
+- `kernel_vars.yml`: `kernel_build_dir: "/usr/src/linux-{{ kernel_version }}-build"`
+- `kernel_git_vars.yml`: `kernel_build_dir: "{{ kernel_git_dir }}"`
+
+The variable name is the same but has completely different semantics. This is confusing and error-prone.
+
+**Fix:** Use distinct variable names:
+- `stable_kernel_build_dir` for tarball builds
+- `git_kernel_build_dir` or just use `kernel_git_dir` directly in git builds
+
+## Minor Issues
+
+### 7. **No Async Timeout Error Handling**
+**File:** `tasks/build_kernel_from_git.yml:43-54`
+
+**Problem:**
+```yaml
+async: 7200
+poll: 30
+```
+
+The kernel build has a 2-hour timeout but no failure handling if the build fails partway through.
+
+**Improvement:** Add error checking and cleanup on failure.
+
+### 8. **Hardcoded RedHat Assumptions**
+**Files:** Multiple tasks
+
+**Problem:**
+- Uses `dnf` package manager (RedHat family only)
+- Hardcoded paths like `/boot/efi/EFI/redhat/grub.cfg`
+- `when: ansible_os_family == "RedHat"` guards some but not all RedHat-specific tasks
+
+**Impact:** Won't work on Debian/Ubuntu without modification despite README claiming "Linux kernel building."
+
+**Fix:** Either:
+- Document that this is RedHat-only
+- Add Debian/Ubuntu support with conditional tasks
+
+### 9. **No Validation of Built Kernel**
+**Files:** Both build task files
+
+**Problem:**
+No verification that `make -j{{ num_cores }}` actually succeeded beyond checking for the marker file. If the build fails mid-way and someone creates the marker file manually, it will skip the build.
+
+**Improvement:**
+- Check for actual kernel artifacts (vmlinuz, modules)
+- Parse make output for errors
+- Use `failed_when` conditions
+
+### 10. **Unclear Documentation in Variables**
+**File:** `vars/kernel_git_vars.yml:6`
+
+**Problem:**
+```yaml
+kernel_git_update: true  # Set to false to skip git pull
+```
+
+This comment is misleading. Looking at `fetch_kernel_git.yml:32`, the update only happens if the repo already exists AND this is true. On first clone, it's always created regardless of this setting.
+
+**Fix:** Update comment to: "Set to false to skip git pull on existing repository"
+
+## Restructuring Recommendations
+
+### Recommended Directory Structure
+
+```
+.
+├── playbooks/
+│   ├── build_kernel_stable.yml      # Renamed for clarity
+│   └── build_kernel_git.yml         # Renamed for clarity
+├── tasks/
+│   ├── common/
+│   │   ├── install_dependencies.yml # Shared dependency installation
+│   │   └── configure_grub.yml       # Shared GRUB configuration
+│   ├── stable/
+│   │   └── build_stable_kernel.yml  # Stable-specific build
+│   └── git/
+│       ├── fetch_kernel_git.yml
+│       ├── fetch_bug_config.yml
+│       └── build_git_kernel.yml
+├── vars/
+│   ├── common.yml                   # Shared variables
+│   ├── stable_kernel.yml            # Stable-specific vars
+│   └── git_kernel.yml               # Git-specific vars
+└── inventory.ini
+```
+
+### Proposed Variable Reorganization
+
+**vars/common.yml:**
+```yaml
+---
+# Build configuration (shared)
+num_cores: "{{ ansible_processor_vcpus | default(2) }}"
+reboot_after_build: false
+grub_cfg_path: "/boot/grub2/grub.cfg"
+
+# Required packages (shared)
+required_packages:
+  - gcc
+  - make
+  # ... full list
+```
+
+**vars/stable_kernel.yml:**
+```yaml
+---
+kernel_version: "6.12.93"
+kernel_source_url: "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-{{ kernel_version }}.tar.xz"
+stable_build_dir: "/usr/src/linux-{{ kernel_version }}-build"
+kernel_config: "defconfig"
+```
+
+**vars/git_kernel.yml:**
+```yaml
+---
+kernel_git_repo: "https://github.com/torvalds/linux.git"
+kernel_git_dir: "/usr/src/linux-git"
+kernel_git_branch: "master"
+kernel_git_update: true
+clean_before_build: true
+install_kernel: false
+```
+
+### Task Consolidation
+
+Create shared tasks:
+
+**tasks/common/install_dependencies.yml:**
+```yaml
+---
+- name: Install kernel build dependencies
+  ansible.builtin.dnf:
+    name: "{{ required_packages }}"
+    state: present
+    update_cache: true
+  become: true
+  when: ansible_os_family == "RedHat"
+```
+
+**tasks/common/configure_grub.yml:**
+```yaml
+---
+- name: Detect GRUB config path (BIOS vs UEFI)
+  ansible.builtin.stat:
+    path: "/boot/efi/EFI/redhat/grub.cfg"
+  register: grub_efi
+
+- name: Set effective GRUB config path
+  ansible.builtin.set_fact:
+    effective_grub_cfg: "{{ '/boot/efi/EFI/redhat/grub.cfg' if grub_efi.stat.exists else grub_cfg_path }}"
+
+- name: Create initramfs for the new kernel
+  ansible.builtin.command: "dracut --force /boot/initramfs-{{ kernel_release.stdout }}.img {{ kernel_release.stdout }}"
+  args:
+    creates: "/boot/initramfs-{{ kernel_release.stdout }}.img"
+  become: true
+  when: ansible_os_family == "RedHat"
+
+- name: Update GRUB configuration
+  ansible.builtin.command: "grub2-mkconfig -o {{ effective_grub_cfg }}"
+  become: true
+  when: ansible_os_family == "RedHat"
+```
+
+This eliminates the duplication of GRUB configuration code across both build tasks.
+
+## Summary of Required Fixes
+
+**High Priority:**
+1. Fix or remove broken syzkaller config URL extraction
+2. Add `become: true` to make clean
+3. Consolidate duplicate variables
+
+**Medium Priority:**
+4. Make make clean idempotent or remove it
+5. Fix grub_cfg_path availability in git builds
+6. Rename conflicting `kernel_build_dir` variables
+
+**Low Priority:**
+7. Add build validation
+8. Improve error handling
+9. Document RedHat-only limitations
+10. Clarify variable documentation

--- a/FIXES_APPLIED.md
+++ b/FIXES_APPLIED.md
@@ -1,0 +1,169 @@
+# Fixes Applied
+
+This document describes the fixes and restructuring applied to the kernel_build_ansible project.
+
+## Files Modified
+
+### Critical Fixes
+
+#### 1. Fixed Broken Syzkaller Config URL Extraction
+**File:** `tasks/fetch_bug_config.yml`
+
+**Changes:**
+- Removed broken regex-based URL extraction that attempted to derive config hash from bug extid
+- Added clear error message directing users to manually extract the kernel config URL
+- Added documentation explaining why automatic extraction is impossible
+
+**Impact:** Users must now manually copy the kernel config URL from syzkaller bug pages instead of relying on broken automatic extraction.
+
+**Migration:**
+```yaml
+# OLD (broken):
+bug_url: "https://syzkaller.appspot.com/bug?extid=f2b5401166003c7d09c1"
+
+# NEW (working):
+# 1. Visit the bug URL
+# 2. Click "Kernel config" link
+# 3. Copy that URL:
+kernel_bug_config_url: "https://syzkaller.appspot.com/text?tag=KernelConfig&x=3e19fa1907a3dfda"
+```
+
+#### 2. Added Missing Root Permissions to make clean
+**File:** `tasks/build_kernel.yml`
+
+**Changes:**
+- Added `become: true` to the make clean task
+- Made make clean conditional on `clean_before_build` variable (default: false)
+
+**Impact:** Stable kernel builds now support optional cleaning and won't fail with permission errors.
+
+### Variable Consolidation
+
+#### 3. Created Common Variables File
+**File:** `vars/common.yml` (NEW)
+
+**Changes:**
+- Extracted shared variables from `kernel_vars.yml` and `kernel_git_vars.yml`:
+  - `num_cores`
+  - `reboot_after_build`
+  - `grub_cfg_path`
+  - `required_packages`
+
+**Impact:** Single source of truth for shared configuration, easier maintenance.
+
+#### 4. Updated Playbooks to Load Common Variables
+**Files:** `build_kernel.yml`, `build_kernel_from_bug.yml`
+
+**Changes:**
+- Added `vars/common.yml` to `vars_files` list (loaded first)
+- Removed `vars/kernel_vars.yml` from git playbook (not needed)
+
+**Migration:** No changes needed - common.yml is automatically loaded.
+
+#### 5. Cleaned Up Variable Files
+**Files:** `vars/kernel_vars.yml`, `vars/kernel_git_vars.yml`
+
+**Changes:**
+- Removed duplicate variables now in common.yml
+- Added documentation comments referencing common.yml
+- Added `clean_before_build` variable to kernel_vars.yml for consistency
+- Improved documentation for `kernel_git_update` variable
+- Removed `bug_url` support (broken feature)
+- Made `kernel_bug_config_url` the only supported method
+
+**Impact:** Clearer separation of concerns, reduced duplication.
+
+## Files Added
+
+1. **CLAUDE.md** - Comprehensive documentation for Claude Code
+2. **CODE_REVIEW.md** - Detailed analysis of all issues found
+3. **vars/common.yml** - Shared variables across all builds
+4. **FIXES_APPLIED.md** - This file
+
+## Remaining Issues (Not Fixed)
+
+The following issues from CODE_REVIEW.md were documented but not fixed in this pass:
+
+### Moderate Priority
+- **Inconsistent kernel_build_dir naming:** The variable has different semantics in stable vs git builds. Consider renaming to `stable_build_dir` and `git_build_dir` in a future refactor.
+
+### Low Priority
+- **No build validation:** The build success is only verified by checking for marker files, not actual kernel artifacts.
+- **No async error handling:** Long builds timeout after 2 hours but there's no cleanup on partial failure.
+- **RedHat-only support:** The playbooks are hardcoded for Fedora/RHEL. Adding Debian/Ubuntu support would require additional work.
+- **Hardcoded GRUB paths:** UEFI detection uses RedHat-specific paths.
+
+## Testing Recommendations
+
+After applying these fixes, test the following scenarios:
+
+### Test 1: Stable Kernel Build
+```bash
+# Verify common.yml is loaded and build works
+ansible-playbook -i inventory.ini build_kernel.yml --check
+
+# Verify clean_before_build works
+ansible-playbook -i inventory.ini build_kernel.yml -e "clean_before_build=true" --check
+```
+
+### Test 2: Git Kernel Build with Direct Config URL
+```bash
+# Edit vars/kernel_git_vars.yml:
+# kernel_bug_config_url: "https://syzkaller.appspot.com/text?tag=KernelConfig&x=XXXXX"
+
+ansible-playbook -i inventory.ini build_kernel_from_bug.yml --check
+```
+
+### Test 3: Git Kernel Build without Config
+```bash
+# Comment out kernel_bug_config_url in vars/kernel_git_vars.yml
+ansible-playbook -i inventory.ini build_kernel_from_bug.yml --check
+# Should use defconfig
+```
+
+### Test 4: Variable Override
+```bash
+# Verify extra vars still work
+ansible-playbook -i inventory.ini build_kernel_from_bug.yml \
+  -e "num_cores=8" \
+  -e "install_kernel=false" \
+  --check
+```
+
+## Backward Compatibility
+
+### Breaking Changes
+
+1. **bug_url is no longer supported** - Users relying on `bug_url` variable must switch to `kernel_bug_config_url`
+
+   **Migration:**
+   - Visit the syzkaller bug URL in a browser
+   - Find and click the "Kernel config" link
+   - Copy the direct config URL
+   - Set `kernel_bug_config_url` to that URL
+
+2. **make clean behavior changed** - In stable builds, make clean is now conditional (default: off)
+
+   **Migration:**
+   - To preserve old behavior: set `clean_before_build: true` in `kernel_vars.yml`
+   - Recommended: leave as false for faster, idempotent builds
+
+### Non-Breaking Changes
+
+All other changes are backward compatible:
+- Common variables are loaded automatically
+- Extra vars (`-e`) override behavior unchanged
+- All existing variable names still work
+- Playbook interfaces unchanged
+
+## Files You Can Remove (Optional)
+
+None. All original files were updated in-place.
+
+## Recommended Next Steps
+
+1. **Test the fixes** using the test scenarios above
+2. **Update README.md** to reflect the `kernel_bug_config_url` requirement
+3. **Consider the restructuring recommendations** in CODE_REVIEW.md for a more maintainable layout
+4. **Add build validation** to verify kernel artifacts exist after build
+5. **Add Debian/Ubuntu support** if needed for broader compatibility

--- a/README.md
+++ b/README.md
@@ -41,24 +41,35 @@ ansible-playbook build_kernel_from_bug.yml
 
 Configuration in `vars/kernel_git_vars.yml`:
 
-#### Using a syzkaller bug URL:
-```yaml
-bug_url: "https://syzkaller.appspot.com/bug?extid=f2b5401166003c7d09c1"
-```
+To use a kernel config from a syzkaller bug report:
 
-#### Using a direct config URL:
+1. Visit the bug URL (e.g., `https://syzkaller.appspot.com/bug?extid=f2b5401166003c7d09c1`)
+2. Click the "Kernel config" link on the bug page
+3. Copy the config URL from your browser
+4. Set it in `vars/kernel_git_vars.yml`:
+
 ```yaml
 kernel_bug_config_url: "https://syzkaller.appspot.com/text?tag=KernelConfig&x=3e19fa1907a3dfda"
 ```
 
 ## Configuration Options
 
-### Common Variables (`vars/kernel_vars.yml`)
+### Common Variables (`vars/common.yml`)
+
+These variables apply to all build types:
 
 ```yaml
 num_cores: 4                    # Number of CPU cores for parallel build
 reboot_after_build: false       # Auto-reboot after installation
 grub_cfg_path: "/boot/grub2/grub.cfg"
+```
+
+### Stable Kernel Variables (`vars/kernel_vars.yml`)
+
+```yaml
+kernel_version: "6.12.93"       # Kernel version to build
+kernel_config: "defconfig"      # Configuration method
+clean_before_build: false       # Run 'make clean' before build
 ```
 
 ### Git-specific Variables (`vars/kernel_git_vars.yml`)
@@ -76,13 +87,18 @@ install_kernel: false           # Install after building
 
 ### Example 1: Build latest kernel with syzkaller bug config
 
-1. Edit `vars/kernel_git_vars.yml`:
+1. Visit the bug page and get the kernel config URL:
+   - Go to: `https://syzkaller.appspot.com/bug?extid=f2b5401166003c7d09c1`
+   - Click "Kernel config" link
+   - Copy the URL
+
+2. Edit `vars/kernel_git_vars.yml`:
 ```yaml
-bug_url: "https://syzkaller.appspot.com/bug?extid=f2b5401166003c7d09c1"
+kernel_bug_config_url: "https://syzkaller.appspot.com/text?tag=KernelConfig&x=3e19fa1907a3dfda"
 install_kernel: false  # Just build, don't install
 ```
 
-2. Run the playbook:
+3. Run the playbook:
 ```bash
 ansible-playbook build_kernel_from_bug.yml
 ```
@@ -136,19 +152,23 @@ ansible-playbook build_kernel_from_bug.yml
 
 1. Find a syzkaller bug report (e.g., https://syzkaller.appspot.com/bug?extid=f2b5401166003c7d09c1)
 
-2. Copy the bug URL to `vars/kernel_git_vars.yml`:
+2. Open the bug page in your browser and extract the kernel config URL:
+   - Click the "Kernel config" link on the bug page
+   - Copy the URL (e.g., `https://syzkaller.appspot.com/text?tag=KernelConfig&x=3e19fa1907a3dfda`)
+
+3. Add the config URL to `vars/kernel_git_vars.yml`:
 ```yaml
-bug_url: "https://syzkaller.appspot.com/bug?extid=f2b5401166003c7d09c1"
+kernel_bug_config_url: "https://syzkaller.appspot.com/text?tag=KernelConfig&x=3e19fa1907a3dfda"
 ```
 
-3. Build the kernel:
+4. Build the kernel:
 ```bash
 ansible-playbook build_kernel_from_bug.yml
 ```
 
-4. The playbook will:
+5. The playbook will:
    - Clone/update the Linux git repository
-   - Download the kernel config from the bug report
+   - Download the kernel config from the URL
    - Build the kernel with that config
    - Optionally install the kernel
 

--- a/build_kernel.yml
+++ b/build_kernel.yml
@@ -2,6 +2,7 @@
 - name: Build Linux Kernel from Source
   hosts: all
   vars_files:
+    - vars/common.yml
     - vars/kernel_vars.yml
 
   tasks:

--- a/build_kernel_from_bug.yml
+++ b/build_kernel_from_bug.yml
@@ -2,7 +2,7 @@
 - name: Build Linux Kernel from Git with Bug Config
   hosts: all
   vars_files:
-    - vars/kernel_vars.yml
+    - vars/common.yml
     - vars/kernel_git_vars.yml
 
   tasks:

--- a/tasks/build_kernel.yml
+++ b/tasks/build_kernel.yml
@@ -46,6 +46,8 @@
   ansible.builtin.command: "make clean"
   args:
     chdir: "{{ kernel_build_dir }}"
+  become: true
+  when: clean_before_build | default(false)
     
 - name: Build kernel and modules
   ansible.builtin.shell: |

--- a/tasks/fetch_bug_config.yml
+++ b/tasks/fetch_bug_config.yml
@@ -1,8 +1,21 @@
 ---
-- name: Extract config URL from syzkaller bug
-  ansible.builtin.set_fact:
-    config_url: "{{ bug_url | regex_replace('.*bug\\?extid=', 'https://syzkaller.appspot.com/text?tag=KernelConfig&x=') }}"
-  when: bug_url is defined and 'syzkaller.appspot.com/bug' in bug_url
+# NOTE: Cannot automatically extract config URL from bug URL because the
+# kernel config hash is not derivable from the bug extid. Users must:
+# 1. Visit the bug URL in a browser
+# 2. Find the "Kernel config" link
+# 3. Copy that URL to kernel_bug_config_url variable
+#
+# This task now only handles direct config URLs via kernel_bug_config_url
+
+- name: Fail if bug_url is provided without config_url
+  ansible.builtin.fail:
+    msg: |
+      Cannot automatically extract kernel config from bug URL.
+      Please visit {{ bug_url }} and copy the "Kernel config" link.
+      Then set: kernel_bug_config_url: "<the config URL>"
+  when:
+    - bug_url is defined
+    - kernel_bug_config_url is not defined
 
 - name: Use direct config URL if provided
   ansible.builtin.set_fact:

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -1,0 +1,28 @@
+---
+# Common variables shared across all kernel builds
+
+# Build configuration
+num_cores: "{{ ansible_processor_vcpus | default(2) }}"
+reboot_after_build: false
+grub_cfg_path: "/boot/grub2/grub.cfg"
+
+# Required packages for kernel build (Fedora/RHEL)
+required_packages:
+  - gcc
+  - make
+  - ncurses-devel
+  - bison
+  - flex
+  - openssl-devel
+  - elfutils-libelf-devel
+  - dwarves
+  - git
+  - wget
+  - xz
+  - bc
+  - openssl
+  - perl
+  - python3
+  - rsync
+  - rpm-build
+  - rpmdevtools

--- a/vars/kernel_git_vars.yml
+++ b/vars/kernel_git_vars.yml
@@ -1,23 +1,26 @@
 ---
+# Git kernel build variables
+# Common variables (num_cores, packages, grub_cfg_path, etc.) are in vars/common.yml
+
 # Git repository configuration
 kernel_git_repo: "https://github.com/torvalds/linux.git"
 kernel_git_dir: "/usr/src/linux-git"
 kernel_git_branch: "master"  # or specify a specific branch/tag
-kernel_git_update: true  # Set to false to skip git pull
+kernel_git_update: true  # Set to false to skip git pull on existing repository
 # kernel_git_depth: 1  # Uncomment for shallow clone (faster, less disk space)
 
 # Use kernel_git_dir as build directory when working from git
 kernel_build_dir: "{{ kernel_git_dir }}"
 
 # Bug report configuration
-# Option 1: Provide the bug URL directly (will extract config URL automatically)
-# bug_url: "https://syzkaller.appspot.com/bug?extid=f2b5401166003c7d09c1"
-
-# Option 2: Provide the direct config URL
-# kernel_bug_config_url: "https://syzkaller.appspot.com/text?tag=KernelConfig&x=3e19fa1907a3dfda"
+# NOTE: Cannot automatically extract config from bug URL.
+# Visit the bug URL, find "Kernel config" link, and paste the direct URL below.
+#
+# Example bug URL: https://syzkaller.appspot.com/bug?extid=f2b5401166003c7d09c1
+# Example config URL: https://syzkaller.appspot.com/text?tag=KernelConfig&x=3e19fa1907a3dfda
+# bug_url: "https://syzkaller.appspot.com/bug?extid=f2b5401166003c7d09c1"  # For reference only
+kernel_bug_config_url: ""  # REQUIRED: Direct kernel config URL from syzkaller
 
 # Build options
 clean_before_build: true
 install_kernel: false  # Set to true to install the built kernel
-num_cores: "{{ ansible_processor_vcpus | default(2) }}"
-reboot_after_build: false

--- a/vars/kernel_vars.yml
+++ b/vars/kernel_vars.yml
@@ -1,4 +1,7 @@
 ---
+# Stable kernel build variables
+# Common variables (num_cores, packages, etc.) are in vars/common.yml
+
 # Kernel source configuration
 kernel_version: "6.12.93"  # Change this to your desired kernel version
 kernel_source_url: "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-{{ kernel_version }}.tar.xz"
@@ -6,27 +9,4 @@ kernel_build_dir: "/usr/src/linux-{{ kernel_version }}-build"
 
 # Build configuration
 kernel_config: "defconfig"  # Options: defconfig, oldconfig
-num_cores: "{{ ansible_processor_vcpus | default(2) }}"
-grub_cfg_path: "/boot/grub2/grub.cfg"
-reboot_after_build: false
-
-# Required packages for kernel build (Fedora/RHEL)
-required_packages:
-  - gcc
-  - make
-  - ncurses-devel
-  - bison
-  - flex
-  - openssl-devel
-  - elfutils-libelf-devel
-  - dwarves
-  - git
-  - wget
-  - xz
-  - bc
-  - openssl
-  - perl
-  - python3
-  - rsync
-  - rpm-build
-  - rpmdevtools
+clean_before_build: false  # Set to true to run 'make clean' before build


### PR DESCRIPTION
This commit addresses multiple issues and improves code maintainability:

Critical Fixes:
- Fix broken syzkaller config URL extraction in fetch_bug_config.yml The regex attempted to derive config hash from bug extid, which is impossible. Now requires manual config URL extraction with clear error messages.
- Add missing 'become: true' to make clean task in build_kernel.yml
- Make 'make clean' conditional on clean_before_build variable

Variable Consolidation:
- Create vars/common.yml for shared variables (num_cores, packages, grub_cfg_path, reboot_after_build)
- Remove duplicate variables from kernel_vars.yml and kernel_git_vars.yml
- Update both playbooks to load common.yml

Documentation:
- Add CLAUDE.md with architecture overview and common commands
- Add CODE_REVIEW.md with detailed issue analysis
- Add FIXES_APPLIED.md with migration guide and testing instructions
- Update README.md to reflect new kernel_bug_config_url workflow

Breaking Changes:
- bug_url variable no longer supported (use kernel_bug_config_url)
- make clean now conditional (default: false) in stable builds